### PR TITLE
Add pure PyTorch backbone.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
             object-position: center top;">
 </div>
 
+<div align="center">
+  <a href="https://discord.gg/gTW9JwST8q" target="_blank">
+    <img src="https://img.shields.io/badge/Join%20Our%20Discord-7289DA?style=for-the-badge&logo=discord&logoColor=white" alt="Discord">
+  </a>
+</div>
+
 ---
 
 Zonos-v0.1 is a leading open-weight text-to-speech model trained on more than 200k hours of varied multilingual speech, delivering expressiveness and quality on par with—or even surpassing—top TTS providers.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,12 @@ _For repeated sampling we highly recommend using the gradio interface instead, a
 
 ## Installation
 
-**At the moment this repository only supports Linux systems (preferably Ubuntu 22.04/24.04) with recent NVIDIA GPUs (3000-series or newer, 6GB+ VRAM).**
+#### System requirements
+
+- **Operating System:** Linux (preferably Ubuntu 22.04/24.04), macOS
+- **GPU:** 6GB+ VRAM, Hybrid additionally requires a 3000-series or newer Nvidia GPU
+
+Note: Zonos can also run on CPU provided there is enough free RAM. However, this will be a lot slower than running on a dedicated GPU, and likely won't be sufficient for interactive use.
 
 See also [Docker Installation](#docker-installation)
 
@@ -90,7 +95,8 @@ See also [Docker Installation](#docker-installation)
 Zonos depends on the eSpeak library phonemization. You can install it on Ubuntu with the following command:
 
 ```bash
-apt install -y espeak-ng
+apt install -y espeak-ng # For Ubuntu
+# brew install espeak-ng # For MacOS
 ```
 
 #### Python dependencies
@@ -101,21 +107,22 @@ We highly recommend using a recent version of [uv](https://docs.astral.sh/uv/#in
 
 ```bash
 uv sync
-uv sync --extra compile
+uv sync --extra compile # optional but needed to run the hybrid
+uv pip install -e .
 ```
 
 ##### Installing into the system/actived environment using uv
 
 ```bash
 uv pip install -e .
-uv pip install -e .[compile]
+uv pip install -e .[compile] # optional but needed to run the hybrid
 ```
 
 ##### Installing into the system/actived environment using pip
 
 ```bash
 pip install -e .
-pip install --no-build-isolation -e .[compile]
+pip install --no-build-isolation -e .[compile] # optional but needed to run the hybrid
 ```
 
 ##### Confirm that it's working

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ cd Zonos
 docker compose up
 
 # Or for development you can do
-docker build -t Zonos .
-docker run -it --gpus=all --net=host -v /path/to/Zonos:/Zonos -t Zonos
+docker build -t zonos .
+docker run -it --gpus=all --net=host -v /path/to/Zonos:/Zonos -t zonos
 cd /Zonos
 python sample.py # this will generate a sample.wav in /Zonos
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ _For repeated sampling we highly recommend using the gradio interface instead, a
 - Audio prefix inputs: Add text plus an audio prefix for even richer speaker matching. Audio prefixes can be used to elicit behaviours such as whispering which can otherwise be challenging to replicate when cloning from speaker embeddings
 - Multilingual support: Zonos-v0.1 supports English, Japanese, Chinese, French, and German
 - Audio quality and emotion control: Zonos offers fine-grained control of many aspects of the generated audio. These include speaking rate, pitch, maximum frequency, audio quality, and various emotions such as happiness, anger, sadness, and fear.
-- Fast: our model runs with a real-time factor of ~2x on an RTX 4090
+- Fast: our model can generate 2 seconds of audio per second of compute time on an RTX 4090 (i.e. real-time factor of 0.5)
 - Gradio WebUI: Zonos comes packaged with an easy to use gradio interface to generate speech
 - Simple installation and deployment: Zonos can be installed and deployed simply using the docker file packaged with our repository.
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ import torch
 import torchaudio
 from zonos.model import Zonos
 from zonos.conditioning import make_cond_dict
+from zonos.utils import DEFAULT_DEVICE as device
 
-# model = Zonos.from_pretrained("Zyphra/Zonos-v0.1-hybrid", device="cuda")
-model = Zonos.from_pretrained("Zyphra/Zonos-v0.1-transformer", device="cuda")
+# model = Zonos.from_pretrained("Zyphra/Zonos-v0.1-hybrid", device=device)
+model = Zonos.from_pretrained("Zyphra/Zonos-v0.1-transformer", device=device)
 
 wav, sampling_rate = torchaudio.load("assets/exampleaudio.mp3")
 speaker = model.make_speaker_embedding(wav, sampling_rate)

--- a/gradio_interface.py
+++ b/gradio_interface.py
@@ -3,9 +3,12 @@ import torchaudio
 import gradio as gr
 from os import getenv
 
-from zonos.model import Zonos, ZonosBackbone
+from zonos.model import Zonos
 from zonos.conditioning import make_cond_dict, supported_language_codes
 from zonos.utils import DEFAULT_DEVICE as device
+from zonos.backbone import BACKBONES
+
+ZonosBackbone = next(iter(BACKBONES.values()))
 
 CURRENT_MODEL_TYPE = None
 CURRENT_MODEL = None

--- a/gradio_interface.py
+++ b/gradio_interface.py
@@ -3,10 +3,10 @@ import torchaudio
 import gradio as gr
 from os import getenv
 
-from zonos.model import Zonos
+from zonos.model import Zonos, ZonosBackbone
 from zonos.conditioning import make_cond_dict, supported_language_codes
+from zonos.utils import DEFAULT_DEVICE as device
 
-device = "cuda"
 CURRENT_MODEL_TYPE = None
 CURRENT_MODEL = None
 
@@ -138,8 +138,7 @@ def generate_audio(
         wav_prefix = wav_prefix.mean(0, keepdim=True)
         wav_prefix = torchaudio.functional.resample(wav_prefix, sr_prefix, selected_model.autoencoder.sampling_rate)
         wav_prefix = wav_prefix.to(device, dtype=torch.float32)
-        with torch.autocast(device, dtype=torch.float32):
-            audio_prefix_codes = selected_model.autoencoder.encode(wav_prefix.unsqueeze(0))
+        audio_prefix_codes = selected_model.autoencoder.encode(wav_prefix.unsqueeze(0))
 
     emotion_tensor = torch.tensor(list(map(float, [e1, e2, e3, e4, e5, e6, e7, e8])), device=device)
 
@@ -187,12 +186,24 @@ def generate_audio(
 
 
 def build_interface():
+    supported_models = []
+    if "transformer" in ZonosBackbone.supported_architectures:
+        supported_models.append("Zyphra/Zonos-v0.1-transformer")
+
+    if "hybrid" in ZonosBackbone.supported_architectures:
+        supported_models.append("Zyphra/Zonos-v0.1-hybrid")
+    else:
+        print(
+            "| The current ZonosBackbone does not support the hybrid architecture, meaning only the transformer model will be available in the model selector.\n"
+            "| This probably means the mamba-ssm library has not been installed."
+        )
+
     with gr.Blocks() as demo:
         with gr.Row():
             with gr.Column():
                 model_choice = gr.Dropdown(
-                    choices=["Zyphra/Zonos-v0.1-transformer", "Zyphra/Zonos-v0.1-hybrid"],
-                    value="Zyphra/Zonos-v0.1-transformer",
+                    choices=supported_models,
+                    value=supported_models[0],
                     label="Zonos Model Type",
                     info="Select the model variant to use.",
                 )

--- a/gradio_interface.py
+++ b/gradio_interface.py
@@ -3,12 +3,9 @@ import torchaudio
 import gradio as gr
 from os import getenv
 
-from zonos.model import Zonos
+from zonos.model import Zonos, DEFAULT_BACKBONE_CLS as ZonosBackbone
 from zonos.conditioning import make_cond_dict, supported_language_codes
 from zonos.utils import DEFAULT_DEVICE as device
-from zonos.backbone import BACKBONES
-
-ZonosBackbone = next(iter(BACKBONES.values()))
 
 CURRENT_MODEL_TYPE = None
 CURRENT_MODEL = None
@@ -139,7 +136,7 @@ def generate_audio(
     if prefix_audio is not None:
         wav_prefix, sr_prefix = torchaudio.load(prefix_audio)
         wav_prefix = wav_prefix.mean(0, keepdim=True)
-        wav_prefix = torchaudio.functional.resample(wav_prefix, sr_prefix, selected_model.autoencoder.sampling_rate)
+        wav_prefix = selected_model.autoencoder.preprocess(wav_prefix, sr_prefix)
         wav_prefix = wav_prefix.to(device, dtype=torch.float32)
         audio_prefix_codes = selected_model.autoencoder.encode(wav_prefix.unsqueeze(0))
 

--- a/gradio_interface.py
+++ b/gradio_interface.py
@@ -10,6 +10,9 @@ from zonos.utils import DEFAULT_DEVICE as device
 CURRENT_MODEL_TYPE = None
 CURRENT_MODEL = None
 
+SPEAKER_EMBEDDING = None
+SPEAKER_AUDIO_PATH = None
+
 
 def load_model_if_needed(model_choice: str):
     global CURRENT_MODEL_TYPE, CURRENT_MODEL
@@ -122,15 +125,20 @@ def generate_audio(
     seed = int(seed)
     max_new_tokens = 86 * 30
 
+    # This is a bit ew, but works for now.
+    global SPEAKER_AUDIO_PATH, SPEAKER_EMBEDDING
+
     if randomize_seed:
         seed = torch.randint(0, 2**32 - 1, (1,)).item()
     torch.manual_seed(seed)
 
-    speaker_embedding = None
     if speaker_audio is not None and "speaker" not in unconditional_keys:
-        wav, sr = torchaudio.load(speaker_audio)
-        speaker_embedding = selected_model.make_speaker_embedding(wav, sr)
-        speaker_embedding = speaker_embedding.to(device, dtype=torch.bfloat16)
+        if speaker_audio != SPEAKER_AUDIO_PATH:
+            print("Recomputed speaker embedding")
+            wav, sr = torchaudio.load(speaker_audio)
+            SPEAKER_EMBEDDING = selected_model.make_speaker_embedding(wav, sr)
+            SPEAKER_EMBEDDING = SPEAKER_EMBEDDING.to(device, dtype=torch.bfloat16)
+            SPEAKER_AUDIO_PATH = speaker_audio
 
     audio_prefix_codes = None
     if prefix_audio is not None:
@@ -148,7 +156,7 @@ def generate_audio(
     cond_dict = make_cond_dict(
         text=text,
         language=language,
-        speaker=speaker_embedding,
+        speaker=SPEAKER_EMBEDDING,
         emotion=emotion_tensor,
         vqscore_8=vq_tensor,
         fmax=fmax,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,7 @@ dependencies = [
     "gradio>=5.15.0",
 ]
 
-# Note: Not actually optional. All the modeling code lives in mamba-ssm.
-# We put them here to make the two-stage installation process easier.
+# These are technically optional, but mamba-ssm is required to run hybrid models.
 [project.optional-dependencies]
 compile = [
     "flash-attn>=2.7.3",

--- a/sample.py
+++ b/sample.py
@@ -2,9 +2,10 @@ import torch
 import torchaudio
 from zonos.model import Zonos
 from zonos.conditioning import make_cond_dict
+from zonos.utils import DEFAULT_DEVICE as device
 
-# Use the hybrid with "Zyphra/Zonos-v0.1-hybrid"
-model = Zonos.from_pretrained("Zyphra/Zonos-v0.1-transformer", device="cuda")
+# model = Zonos.from_pretrained("Zyphra/Zonos-v0.1-hybrid", device=device)
+model = Zonos.from_pretrained("Zyphra/Zonos-v0.1-transformer", device=device)
 
 wav, sampling_rate = torchaudio.load("assets/exampleaudio.mp3")
 speaker = model.make_speaker_embedding(wav, sampling_rate)

--- a/zonos/autoencoder.py
+++ b/zonos/autoencoder.py
@@ -23,4 +23,5 @@ class DACAutoencoder:
         return self.dac.encode(wav).audio_codes
 
     def decode(self, codes: torch.Tensor) -> torch.Tensor:
-        return self.dac.decode(audio_codes=codes).audio_values.unsqueeze(1)
+        with torch.autocast(self.dac.device.type, torch.float16):
+            return self.dac.decode(audio_codes=codes).audio_values.unsqueeze(1).float()

--- a/zonos/backbone/__init__.py
+++ b/zonos/backbone/__init__.py
@@ -1,0 +1,4 @@
+try:
+    from ._mamba_ssm import ZonosBackbone
+except ImportError:
+    from ._torch import ZonosBackbone

--- a/zonos/backbone/__init__.py
+++ b/zonos/backbone/__init__.py
@@ -1,4 +1,12 @@
+BACKBONES = {}
+
 try:
-    from ._mamba_ssm import ZonosBackbone
+    from ._mamba_ssm import MambaSSMZonosBackbone
+
+    BACKBONES["mamba_ssm"] = MambaSSMZonosBackbone
 except ImportError:
-    from ._torch import ZonosBackbone
+    pass
+
+from ._torch import TorchZonosBackbone
+
+BACKBONES["torch"] = TorchZonosBackbone

--- a/zonos/backbone/_mamba_ssm.py
+++ b/zonos/backbone/_mamba_ssm.py
@@ -4,9 +4,10 @@ from mamba_ssm.models.mixer_seq_simple import create_block
 from mamba_ssm.ops.triton.layer_norm import layer_norm_fn
 
 from zonos.config import BackboneConfig, InferenceParams
+from zonos.utils import find_multiple
 
 
-class ZonosBackbone(nn.Module):
+class MambaSSMZonosBackbone(nn.Module):
     supported_architectures = ["transformer", "hybrid"]
 
     def __init__(self, config: BackboneConfig):
@@ -36,6 +37,7 @@ class ZonosBackbone(nn.Module):
         self.norm_f = nn.LayerNorm(config.d_model, eps=config.norm_epsilon)
 
     def allocate_inference_cache(self, batch_size: int, max_seqlen: int, dtype: torch.dtype = torch.bfloat16):
+        max_seqlen = find_multiple(max_seqlen, 8)
         return {
             i: layer.allocate_inference_cache(batch_size, max_seqlen, dtype=dtype)
             for i, layer in enumerate(self.layers)

--- a/zonos/backbone/_mamba_ssm.py
+++ b/zonos/backbone/_mamba_ssm.py
@@ -2,12 +2,13 @@ import torch
 import torch.nn as nn
 from mamba_ssm.models.mixer_seq_simple import create_block
 from mamba_ssm.ops.triton.layer_norm import layer_norm_fn
-from mamba_ssm.utils.generation import InferenceParams
 
-from zonos.config import BackboneConfig
+from zonos.config import BackboneConfig, InferenceParams
 
 
 class ZonosBackbone(nn.Module):
+    supported_architectures = ["transformer", "hybrid"]
+
     def __init__(self, config: BackboneConfig):
         super().__init__()
         self.config = config
@@ -33,6 +34,12 @@ class ZonosBackbone(nn.Module):
         )
 
         self.norm_f = nn.LayerNorm(config.d_model, eps=config.norm_epsilon)
+
+    def allocate_inference_cache(self, batch_size: int, max_seqlen: int, dtype: torch.dtype = torch.bfloat16):
+        return {
+            i: layer.allocate_inference_cache(batch_size, max_seqlen, dtype=dtype)
+            for i, layer in enumerate(self.layers)
+        }
 
     def forward(self, hidden_states: torch.Tensor, inference_params: InferenceParams | None = None):
         residual = None

--- a/zonos/backbone/_mamba_ssm.py
+++ b/zonos/backbone/_mamba_ssm.py
@@ -4,7 +4,6 @@ from mamba_ssm.models.mixer_seq_simple import create_block
 from mamba_ssm.ops.triton.layer_norm import layer_norm_fn
 
 from zonos.config import BackboneConfig, InferenceParams
-from zonos.utils import find_multiple
 
 
 class MambaSSMZonosBackbone(nn.Module):
@@ -37,7 +36,6 @@ class MambaSSMZonosBackbone(nn.Module):
         self.norm_f = nn.LayerNorm(config.d_model, eps=config.norm_epsilon)
 
     def allocate_inference_cache(self, batch_size: int, max_seqlen: int, dtype: torch.dtype = torch.bfloat16):
-        max_seqlen = find_multiple(max_seqlen, 8)
         return {
             i: layer.allocate_inference_cache(batch_size, max_seqlen, dtype=dtype)
             for i, layer in enumerate(self.layers)

--- a/zonos/backbone/_torch.py
+++ b/zonos/backbone/_torch.py
@@ -1,0 +1,153 @@
+# Based on gpt-fast: https://github.com/pytorch-labs/gpt-fast/blob/095b2229ee3a40e379c11f05b94bd6923db63b4b/model.py
+import torch
+import torch.nn as nn
+from torch.nn import functional as F
+
+from zonos.config import BackboneConfig, InferenceParams
+
+
+def precompute_freqs_cis(seq_len: int, n_elem: int, base: float = 10000) -> torch.Tensor:
+    freqs = 1.0 / (base ** (torch.arange(0, n_elem, 2)[: (n_elem // 2)].float() / n_elem))
+    t = torch.arange(seq_len, device=freqs.device)
+    freqs = torch.outer(t, freqs)
+    freqs_cis = torch.polar(torch.ones_like(freqs), freqs)
+    cache = torch.stack([freqs_cis.real, freqs_cis.imag], dim=-1)
+    return cache
+
+
+def apply_rotary_emb(x: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+    xshaped = x.float().reshape(*x.shape[:-1], -1, 2)
+    freqs_cis = freqs_cis.view(-1, xshaped.size(1), 1, xshaped.size(3), 2)
+    x_out2 = torch.stack(
+        [
+            xshaped[..., 0] * freqs_cis[..., 0] - xshaped[..., 1] * freqs_cis[..., 1],
+            xshaped[..., 1] * freqs_cis[..., 0] + xshaped[..., 0] * freqs_cis[..., 1],
+        ],
+        -1,
+    )
+
+    x_out2 = x_out2.flatten(3)
+    return x_out2.type_as(x)
+
+
+def _update_kv_cache(
+    k: torch.Tensor, v: torch.Tensor, inference_params: InferenceParams, layer_idx: int
+) -> torch.Tensor:
+    """k/v: (batch_size, seqlen, nheads, head_dim) or (batch_size, 1, nheads, head_dim)"""
+    assert layer_idx in inference_params.key_value_memory_dict
+    kv_cache, _ = inference_params.key_value_memory_dict[layer_idx]
+    # Adjust key and value for inference
+    batch_start = inference_params.batch_size_offset
+    batch_end = batch_start + k.shape[0]
+    sequence_start = inference_params.seqlen_offset
+    sequence_end = sequence_start + k.shape[1]
+    assert batch_end <= kv_cache.shape[0]
+    assert sequence_end <= kv_cache.shape[1]
+    assert kv_cache is not None
+    kv_cache[batch_start:batch_end, sequence_start:sequence_end, 0, ...] = k
+    kv_cache[batch_start:batch_end, sequence_start:sequence_end, 1, ...] = v
+    return kv_cache[batch_start:batch_end, :sequence_end, ...]
+
+
+class ZonosBackbone(nn.Module):
+    supported_architectures = ["transformer"]
+    freqs_cis: torch.Tensor
+
+    def __init__(self, config: BackboneConfig):
+        assert not config.ssm_cfg, "This backbone implementation only supports the Transformer model."
+        super().__init__()
+        self.config = config
+
+        self.layers = nn.ModuleList(TransformerBlock(config, i) for i in range(config.n_layer))
+        self.norm_f = nn.LayerNorm(config.d_model, eps=config.norm_epsilon)
+
+    def allocate_inference_cache(self, batch_size: int, max_seqlen: int, dtype: torch.dtype = torch.bfloat16):
+        # TODO: This function should be pure
+        head_dim = self.config.d_model // self.config.attn_cfg["num_heads"]
+        self.freqs_cis = precompute_freqs_cis(16384, head_dim)
+
+        return {
+            i: layer.allocate_inference_cache(batch_size, max_seqlen, dtype=dtype)
+            for i, layer in enumerate(self.layers)
+        }
+
+    def forward(self, hidden_states: torch.Tensor, inference_params: InferenceParams) -> torch.Tensor:
+        input_pos = torch.arange(0, hidden_states.shape[1], device=hidden_states.device)
+        input_pos = input_pos + inference_params.lengths_per_sample.unsqueeze(-1)
+
+        freqs_cis = self.freqs_cis[input_pos].expand(hidden_states.shape[0], -1, -1, -1)
+        for i, layer in enumerate(self.layers):
+            hidden_states = layer(hidden_states, inference_params, freqs_cis)
+        return self.norm_f(hidden_states)
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, config: BackboneConfig, layer_idx: int) -> None:
+        super().__init__()
+        self.config = config
+
+        self.norm = nn.LayerNorm(config.d_model, eps=config.norm_epsilon)
+        self.mixer = Attention(config, layer_idx)
+        self.norm2 = nn.LayerNorm(config.d_model, eps=config.norm_epsilon)
+        self.mlp = FeedForward(config)
+
+        self.num_heads_kv = config.attn_cfg["num_heads_kv"]
+        self.head_dim = config.d_model // config.attn_cfg["num_heads"]
+
+    def allocate_inference_cache(self, batch_size: int, max_seqlen: int, dtype: torch.dtype = torch.bfloat16):
+        return torch.empty(batch_size, max_seqlen, 2, self.num_heads_kv, self.head_dim, dtype=dtype), None
+
+    def forward(self, x: torch.Tensor, inference_params: InferenceParams, freqs_cis: torch.Tensor) -> torch.Tensor:
+        x = x + self.mixer(self.norm(x), inference_params, freqs_cis)
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class Attention(nn.Module):
+    def __init__(self, config: BackboneConfig, layer_idx: int):
+        super().__init__()
+        self.num_heads = config.attn_cfg["num_heads"]
+        self.num_heads_kv = config.attn_cfg["num_heads_kv"]
+        self.head_dim = config.d_model // self.num_heads
+        self.layer_idx = layer_idx
+
+        total_head_dim = (self.num_heads + 2 * self.num_heads_kv) * self.head_dim
+        self.in_proj = nn.Linear(config.d_model, total_head_dim, bias=False)
+        self.out_proj = nn.Linear(self.num_heads * self.head_dim, config.d_model, bias=False)
+
+    def forward(self, x: torch.Tensor, inference_params: InferenceParams, freqs_cis: torch.Tensor) -> torch.Tensor:
+        batch_size, seqlen, _ = x.shape
+
+        q_size = self.num_heads * self.head_dim
+        kv_size = self.num_heads_kv * self.head_dim
+        q, k, v = self.in_proj(x).split([q_size, kv_size, kv_size], dim=-1)
+
+        q = q.view(batch_size, seqlen, self.num_heads, self.head_dim)
+        k = k.view(batch_size, seqlen, self.num_heads_kv, self.head_dim)
+        v = v.view(batch_size, seqlen, self.num_heads_kv, self.head_dim)
+
+        q = apply_rotary_emb(q, freqs_cis)
+        k = apply_rotary_emb(k, freqs_cis)
+
+        kv = _update_kv_cache(k, v, inference_params, self.layer_idx)
+        k, v = kv.unbind(dim=-3)
+
+        q, k, v = map(lambda x: x.transpose(1, 2), (q, k, v))
+
+        y = F.scaled_dot_product_attention(q, k, v, is_causal=seqlen > 1, enable_gqa=True)
+
+        y = y.transpose(1, 2).contiguous().view(batch_size, seqlen, q_size)
+
+        y = self.out_proj(y)
+        return y
+
+
+class FeedForward(nn.Module):
+    def __init__(self, config: BackboneConfig) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(config.d_model, 2 * config.attn_mlp_d_intermediate, bias=False)
+        self.fc2 = nn.Linear(config.attn_mlp_d_intermediate, config.d_model, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        y, gate = self.fc1(x).chunk(2, dim=-1)
+        return self.fc2(y * F.silu(gate))

--- a/zonos/backbone/_torch.py
+++ b/zonos/backbone/_torch.py
@@ -4,7 +4,6 @@ import torch.nn as nn
 from torch.nn import functional as F
 
 from zonos.config import BackboneConfig, InferenceParams
-from zonos.utils import find_multiple
 
 
 def precompute_freqs_cis(seq_len: int, n_elem: int, base: float = 10000) -> torch.Tensor:
@@ -66,7 +65,6 @@ class TorchZonosBackbone(nn.Module):
         # TODO: This function should be pure
         head_dim = self.config.d_model // self.config.attn_cfg["num_heads"]
         self.freqs_cis = precompute_freqs_cis(16384, head_dim)
-        max_seqlen = find_multiple(max_seqlen, 8)
         return {
             i: layer.allocate_inference_cache(batch_size, max_seqlen, dtype=dtype)
             for i, layer in enumerate(self.layers)

--- a/zonos/conditioning.py
+++ b/zonos/conditioning.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn as nn
 
 from zonos.config import PrefixConditionerConfig
+from zonos.utils import DEFAULT_DEVICE
 
 
 class Conditioner(nn.Module):
@@ -334,7 +335,7 @@ def make_cond_dict(
     dnsmos_ovrl: float = 4.0,
     speaker_noised: bool = False,
     unconditional_keys: Iterable[str] = {"vqscore_8", "dnsmos_ovrl"},
-    device: str = "cuda",
+    device: torch.device | str = DEFAULT_DEVICE,
 ) -> dict:
     """
     A helper to build the 'cond_dict' that the model expects.

--- a/zonos/conditioning.py
+++ b/zonos/conditioning.py
@@ -52,6 +52,8 @@ class Conditioner(nn.Module):
 
 
 # ------- ESPEAK CONTAINMENT ZONE ------------------------------------------------------------------------------------------------------------------------------------------------
+import os
+import sys
 import re
 import unicodedata
 
@@ -61,6 +63,9 @@ import torch.nn as nn
 from kanjize import number2kanji
 from phonemizer.backend import EspeakBackend
 from sudachipy import Dictionary, SplitMode
+
+if sys.platform == "darwin":
+    os.environ["PHONEMIZER_ESPEAK_LIBRARY"] = "/opt/homebrew/lib/libespeak-ng.dylib"
 
 # --- Number normalization code from https://github.com/daniilrobnikov/vits2/blob/main/text/normalize_numbers.py ---
 

--- a/zonos/config.py
+++ b/zonos/config.py
@@ -51,6 +51,7 @@ class ZonosConfig:
     prefix_conditioner: PrefixConditionerConfig
     eos_token_id: int = 1024
     masked_token_id: int = 1025
+    pad_vocab_to_multiple_of: int = 8
 
     @classmethod
     def from_dict(cls, d: dict) -> "ZonosConfig":

--- a/zonos/config.py
+++ b/zonos/config.py
@@ -1,6 +1,29 @@
 from dataclasses import dataclass, field
 from typing import Literal
 
+import torch
+
+
+# https://github.com/state-spaces/mamba/blob//mamba_ssm/utils/generation.py#L18
+@dataclass
+class InferenceParams:
+    """Inference parameters that are passed to the main model in order
+    to efficienly calculate and store the context during inference."""
+
+    max_seqlen: int
+    max_batch_size: int
+    seqlen_offset: int = 0
+    batch_size_offset: int = 0
+    key_value_memory_dict: dict = field(default_factory=dict)
+    lengths_per_sample: torch.Tensor | None = None
+
+    def reset(self, max_seqlen, max_batch_size):
+        self.max_seqlen = max_seqlen
+        self.max_batch_size = max_batch_size
+        self.seqlen_offset = 0
+        if self.lengths_per_sample is not None:
+            self.lengths_per_sample.zero_()
+
 
 @dataclass
 class BackboneConfig:

--- a/zonos/utils.py
+++ b/zonos/utils.py
@@ -1,0 +1,13 @@
+import torch
+
+
+def get_device() -> torch.device:
+    if torch.cuda.is_available():
+        return torch.device(torch.cuda.current_device())
+    # MPS breaks for whatever reason. Uncomment when it's working.
+    # if torch.mps.is_available():
+    #     return torch.device("mps")
+    return torch.device("cpu")
+
+
+DEFAULT_DEVICE = get_device()

--- a/zonos/utils.py
+++ b/zonos/utils.py
@@ -11,16 +11,17 @@ def find_multiple(n: int, k: int) -> int:
 
 def pad_weight_(w: nn.Embedding | nn.Linear, multiple: int):
     """Pad the weight of an embedding or linear layer to a multiple of `multiple`."""
-    if w.weight.shape[1] % multiple == 0:
-        return
-
     if isinstance(w, nn.Embedding):
         # Pad input dim
-        w.weight.data = F.pad(w.weight.data, (0, 0, 0, multiple - w.weight.shape[1]))
+        if w.weight.shape[1] % multiple == 0:
+            return
+        w.weight.data = F.pad(w.weight.data, (0, 0, 0, w.weight.shape[1] % multiple))
         w.num_embeddings, w.embedding_dim = w.weight.shape
     elif isinstance(w, nn.Linear):
         # Pad output dim
-        w.weight.data = F.pad(w.weight.data, (0, 0, 0, multiple - w.weight.shape[0]))
+        if w.weight.shape[0] % multiple == 0:
+            return
+        w.weight.data = F.pad(w.weight.data, (0, 0, 0, w.weight.shape[0] % multiple))
         w.out_features, w.in_features = w.weight.shape
     else:
         raise ValueError(f"Unsupported weight type: {type(w)}")

--- a/zonos/utils.py
+++ b/zonos/utils.py
@@ -1,4 +1,29 @@
 import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def find_multiple(n: int, k: int) -> int:
+    if k == 0 or n % k == 0:
+        return n
+    return n + k - (n % k)
+
+
+def pad_weight_(w: nn.Embedding | nn.Linear, multiple: int):
+    """Pad the weight of an embedding or linear layer to a multiple of `multiple`."""
+    if w.weight.shape[1] % multiple == 0:
+        return
+
+    if isinstance(w, nn.Embedding):
+        # Pad input dim
+        w.weight.data = F.pad(w.weight.data, (0, 0, 0, multiple - w.weight.shape[1]))
+        w.num_embeddings, w.embedding_dim = w.weight.shape
+    elif isinstance(w, nn.Linear):
+        # Pad output dim
+        w.weight.data = F.pad(w.weight.data, (0, 0, 0, multiple - w.weight.shape[0]))
+        w.out_features, w.in_features = w.weight.shape
+    else:
+        raise ValueError(f"Unsupported weight type: {type(w)}")
 
 
 def get_device() -> torch.device:


### PR DESCRIPTION
This PR enables transformer inference without requiring the mamba-ssm dependency. This also means it will run on CPU as well, albeit slowly.

Currently seeing between 20-40 tokens/s (roughly 0.23-0.46x realtime) on an M4 Max with a theoretical 546 GB/s of memory bandwidth, meaning bandwidth utilization is quite poor (at best: `40Hz * (1.6e9 * 2 Byte) = 128 GB/s`).