### PR TITLE
phonemes support in input text

### DIFF
--- a/zonos/conditioning.py
+++ b/zonos/conditioning.py
@@ -200,13 +200,18 @@ def get_backend(language: str) -> "EspeakBackend":
 
 def phonemize(texts: list[str], languages: list[str]) -> list[str]:
     texts = clean(texts, languages)
-
     batch_phonemes = []
     for text, language in zip(texts, languages):
-        backend = get_backend(language)
-        phonemes = backend.phonemize([text], strip=True)
-        batch_phonemes.append(phonemes[0])
-
+        segments = re.split(r'(:phonemize/.*?/)', text)
+        phon_parts = []
+        for seg in segments:
+            if seg.startswith(':phonemize/') and seg.endswith('/'):
+                phon_parts.append(seg[len(':phonemize/'):-1].replace(" ", ""))
+            elif seg:
+                backend = get_backend(language)
+                ph = backend.phonemize([seg], strip=True)
+                phon_parts.append(ph[0])
+        batch_phonemes.append("".join(phon_parts))
     return batch_phonemes
 
 


### PR DESCRIPTION
simplifies alternation/fixing of spelling mistakes with input support on phonemes

example:
   The :phonemize/wɜːld/ is :phonemize/wʌndɚfʊl/

The :phonemize/.../ syntax allows direct phoneme input that will be preserved, while regular text is processed through eSpeak phonemization.

happy to comply with any alternations needed if any