### PR TITLE
Environment variables

### DIFF
--- a/gradio_interface.py
+++ b/gradio_interface.py
@@ -388,4 +388,5 @@ def build_interface():
 if __name__ == "__main__":
     demo = build_interface()
     share = getenv("GRADIO_SHARE", "False").lower() in ("true", "1", "t")
-    demo.launch(server_name="0.0.0.0", server_port=7860, share=share)
+    server_name = getenv("ZONOS_HOST", "0.0.0.0")
+    demo.launch(server_name=server_name, share=share)

--- a/zonos/conditioning.py
+++ b/zonos/conditioning.py
@@ -64,7 +64,7 @@ from kanjize import number2kanji
 from phonemizer.backend import EspeakBackend
 from sudachipy import Dictionary, SplitMode
 
-if sys.platform == "darwin":
+if sys.platform == "darwin" and "PHONEMIZER_ESPEAK_LIBRARY" not in os.environ:
     os.environ["PHONEMIZER_ESPEAK_LIBRARY"] = "/opt/homebrew/lib/libespeak-ng.dylib"
 
 # --- Number normalization code from https://github.com/daniilrobnikov/vits2/blob/main/text/normalize_numbers.py ---


### PR DESCRIPTION
- The 0.0.0.0 IP is not user friendly because when you launch the gradio app it says to visit http://0.0.0.0:7860 but it doesn't work on windows (You have to open http://127.0.0.1:7860 instead). I guess some people would want 0.0.0.0 option but this should not be forced, therefore added an environment variable named `SERVER_NAME` which you can use to override the default 0.0.0.0 (In my case i set SERVER_NAME=127.0.0.1 in order to get it to work on windows)
- server_port being fixed to 7860 is not a good idea because there might be other gradio apps running on the user's machine (gradio uses 7860 by default and counts up), in which case this app will fail to start. By omitting the `server_port`, it will still launch at 7860, but if there already is an app running at port 7860, gradio will automatically increment and start the server at 7861
- PHONEMIZER_ESPEAK_LIBRARY fix: I understand what you had to do to get espeak to work on Macs, but this breaks if you've installed espeak using some other package manager or installed it on a custom location (for example using a custom homebrew path). I made the change so if the PHONEMIZER_ESPEAK_LIBRARY variable is already set, it doesn't override the environment variable. (In my case the program won't work at all because no matter what environment variable i pass it, you would override it here by hardcoding)

Note that none of these are breaking changes. I just had to make these changes to make sure the app works for as many people as possible out of the box.