### PR TITLE
Fixed a Bug where the GPU wont be detected in Docker > 19.03

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: zonos_container
-    runtime: nvidia
+    gpus: all
     network_mode: "host"
     stdin_open: true
     tty: true


### PR DESCRIPTION
runtime: nvidia is exclusively used in nvidia-docker2 
from docker 19.03 onwards --gpus [all|num|dev] should be used