### PR TITLE
fix: Fix packaging to include submodules like backbone

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ compile = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["zonos"]
+include = ["zonos", "zonos.*"]
 
 [tool.uv]
 no-build-isolation-package = ["flash-attn", "mamba-ssm", "causal-conv1d"]


### PR DESCRIPTION
# Fix packaging to include submodules like `backbone`

## Description
This PR updates `pyproject.toml` to ensure all submodules (such as `backbone`) are properly included when installing `zonos`.

## Changes
- Updated `[tool.setuptools.packages.find]` in `pyproject.toml` to:
  ```toml
  [tool.setuptools.packages.find]
  include = ["zonos", "zonos.*"]

## Why?
Currently, installing Zonos with `uv`, i.e.: `uv add git+https://github.com/Zyphra/Zonos` will not fetch the `backbones` submodule, which means the provided example cannot be run since `from zonos.model import Zonos` fails.
