### PR TITLE
add intel xpu support

### DIFF
--- a/zonos/utils.py
+++ b/zonos/utils.py
@@ -29,11 +29,17 @@ def pad_weight_(w: nn.Embedding | nn.Linear, multiple: int):
 
 def get_device() -> torch.device:
     if torch.cuda.is_available():
-        return torch.device(torch.cuda.current_device())
+        device = torch.device(torch.cuda.current_device())
     # MPS breaks for whatever reason. Uncomment when it's working.
-    # if torch.mps.is_available():
+    # elif torch.mps.is_available():
     #     return torch.device("mps")
-    return torch.device("cpu")
+    elif torch.xpu.is_available():
+        device = torch.device("xpu")
+    else:
+        device = torch.device("cpu")
+
+    print(f"Using {device}")
+    return device
 
 
 DEFAULT_DEVICE = get_device()


### PR DESCRIPTION
Thanks to commit 0b697e0

If this patch is applied and torch is installed from xpu branch (`pip install torch torchaudio --index-url https://download.pytorch.org/whl/xpu`)

Then everything starts working on Intel GPUs (tested on Intel ARC A770)

working example of oci container for intel gpu owners: https://github.com/17314642/zonos-oneapi