### PR TITLE
Remove version from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
-version: '3.8'
-
+---
 services:
   zonos:
     build:


### PR DESCRIPTION
Per the warning from Docker Compose when starting...

```
the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```