### PR TITLE
Support for GRADIO_SERVER_PORT

### DIFF
--- a/gradio_interface.py
+++ b/gradio_interface.py
@@ -416,4 +416,6 @@ def build_interface():
 if __name__ == "__main__":
     demo = build_interface()
     share = getenv("GRADIO_SHARE", "False").lower() in ("true", "1", "t")
-    demo.launch(server_name="0.0.0.0", server_port=7860, share=share)
+    port = getenv("GRADIO_SERVER_PORT", "7860")
+    port = int(port)
+    demo.launch(server_name="0.0.0.0", server_port=port, share=share)


### PR DESCRIPTION
Allows to start gradio on different port using `GRADIO_SERVER_PORT=8080 uv run gradio_interface.py`