### PR TITLE
Debug MPS

### DIFF
--- a/zonos/backbone/_torch.py
+++ b/zonos/backbone/_torch.py
@@ -4,6 +4,7 @@ import torch.nn as nn
 from torch.nn import functional as F
 
 from zonos.config import BackboneConfig, InferenceParams
+from zonos.utils import DEFAULT_DEVICE
 
 
 def precompute_freqs_cis(seq_len: int, n_elem: int, base: float = 10000) -> torch.Tensor:
@@ -133,8 +134,10 @@ class Attention(nn.Module):
 
         q, k, v = map(lambda x: x.transpose(1, 2), (q, k, v))
 
+        if DEFAULT_DEVICE == torch.device("mps"):
+            q, k, v = q.cpu(), k.cpu(), v.cpu()
         y = F.scaled_dot_product_attention(q, k, v, is_causal=seqlen > 1, enable_gqa=True)
-
+        y = y.to(DEFAULT_DEVICE)
         y = y.transpose(1, 2).contiguous().view(batch_size, seqlen, q_size)
 
         y = self.out_proj(y)

--- a/zonos/model.py
+++ b/zonos/model.py
@@ -235,7 +235,12 @@ class Zonos(nn.Module):
         # Use CUDA Graphs if supported, and torch.compile otherwise.
         cg = self.can_use_cudagraphs()
         decode_one_token = self._decode_one_token
-        decode_one_token = torch.compile(decode_one_token, dynamic=True, disable=cg or disable_torch_compile)
+        if DEFAULT_DEVICE == torch.device("mps"):
+            decode_one_token = torch.compile(
+                decode_one_token, dynamic=True, backend="aot_eager", disable=cg or disable_torch_compile
+            )
+        else:
+            decode_one_token = torch.compile(decode_one_token, dynamic=True, disable=cg or disable_torch_compile)
 
         unknown_token = -1
         audio_seq_len = prefix_audio_len + max_new_tokens

--- a/zonos/utils.py
+++ b/zonos/utils.py
@@ -31,8 +31,8 @@ def get_device() -> torch.device:
     if torch.cuda.is_available():
         return torch.device(torch.cuda.current_device())
     # MPS breaks for whatever reason. Uncomment when it's working.
-    # if torch.mps.is_available():
-    #     return torch.device("mps")
+    if torch.mps.is_available():
+        return torch.device("mps")
     return torch.device("cpu")
 
 


### PR DESCRIPTION
### EDIT: THIS IS A BAD WORK AROUND. SEE SOLUTION AND DISCUSSION [HERE](https://github.com/Zyphra/Zonos/pull/190)

### Debug MPS Compatibility in Two Locations

This PR includes two fixes to ensure compatibility with the MPS backend (Apple Silicon) in PyTorch:

_**1. 	Fix in backbone/_torch.py (Lines 137–138):**

```
if DEFAULT_DEVICE == torch.device("mps"):
    q, k, v = q.cpu(), k.cpu(), v.cpu()
```

The F.scaled_dot_product_attention function is still not supported on MPS. This patch forces tensors to CPU in that case, avoiding runtime errors._

**Switching from MPS to CPU and back to MPS significantly reduces training speed.**
**This is just a temporary workaround to uncover other issues. Please do not consider this PR for merging.**

**2.	Fix in model.py (Lines 238–243):**

```
if DEFAULT_DEVICE == torch.device("mps"):
    decode_one_token = torch.compile(
        decode_one_token, dynamic=True, backend="aot_eager", disable=cg or disable_torch_compile
    )
else:
    decode_one_token = torch.compile(decode_one_token, dynamic=True, disable=cg or disable_torch_compile)
```

The default backend (inductor) used by torch.compile is not supported on MPS. This change conditionally switches the backend to aot_eager when the selected device is MPS.

These adjustments allow the model to run properly on Apple devices using the MPS backend.