### PR TITLE
load models from local disk

### DIFF
--- a/zonos/model.py
+++ b/zonos/model.py
@@ -1,4 +1,6 @@
 import json
+import os
+from pathlib import Path
 from typing import Callable
 
 import safetensors
@@ -58,8 +60,17 @@ class Zonos(nn.Module):
     def from_pretrained(
         cls, repo_id: str, revision: str | None = None, device: str = DEFAULT_DEVICE, **kwargs
     ) -> "Zonos":
-        config_path = hf_hub_download(repo_id=repo_id, filename="config.json", revision=revision)
-        model_path = hf_hub_download(repo_id=repo_id, filename="model.safetensors", revision=revision)
+        cwd = Path.cwd()
+        base_path = Path(cwd) / "models"
+        normalized = os.path.normpath(repo_id)
+        sub_path = os.path.basename(normalized)
+        config_path = base_path / sub_path / "config.json"
+        model_path = base_path / sub_path / "model.safetensors"
+
+        # the below is the old ways
+        # config_path = hf_hub_download(repo_id=repo_id, filename="config.json", revision=revision)
+        # model_path = hf_hub_download(repo_id=repo_id, filename="model.safetensors", revision=revision)
+
         return cls.from_local(config_path, model_path, device, **kwargs)
 
     @classmethod


### PR DESCRIPTION
add the code that make zonos load models from local disk.
cause the hf cache will lose efficacy by some time after, then it will re-download model from hf. it was cost a lot of time casue the model more than 3GB.

### 1.create "models" folder in the root 
![image](https://github.com/user-attachments/assets/9eb5688e-d44b-4809-840e-6e49dfaedf94)

### 2.git clone the models from [hf](https://huggingface.co/Zyphra) or [modelscope](https://modelscope.cn/organization/Zyphra)
![image](https://github.com/user-attachments/assets/836f1374-6ad3-43d7-a52a-0e5437c35190)
![image](https://github.com/user-attachments/assets/3b7fa606-06c8-43f1-bd94-e13ba906b90b)

### 3.run the zonos 
